### PR TITLE
chore(ci): run Dependabot alongside Renovate for update coverage

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,104 @@
+# Dependabot runs alongside Mend Renovate (renovate.json) on purpose.
+#
+# Every Renovate run in this org was suppressed by Mend's platform-level
+# `mode=silent`, which blocked all PRs and Dependency Dashboards. Dependabot is
+# enabled here so dependency updates stay visible, and so the two tools can be
+# compared side by side before we settle on one. Expect duplicate PRs until then
+# -- that is intentional, not a misconfiguration.
+#
+# Ecosystem coverage mirrors the repo layout: three npm workspaces, one uv-managed
+# Python service, three Dockerfiles, and the workflow pins.
+version: 2
+
+updates:
+  # --- npm workspaces ---
+  - package-ecosystem: "npm"
+    directory: "/bridge"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      bridge-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        # DJ protocol libs are manual-review only (see renovate.json); keep them
+        # out of the grouped PR so each arrives on its own and gets read.
+        exclude-patterns:
+          - "alphatheta-connect"
+          - "stagelinq"
+
+  - package-ecosystem: "npm"
+    directory: "/bridge-app"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      electron-forge:
+        patterns:
+          - "@electron-forge/*"
+      bridge-app-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+        exclude-patterns:
+          - "@electron-forge/*"
+          - "alphatheta-connect"
+          - "stagelinq"
+
+  - package-ecosystem: "npm"
+    directory: "/dashboard"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      dashboard-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- Python service (uv.lock + pyproject.toml) ---
+  - package-ecosystem: "uv"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(deps)"
+    groups:
+      server-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- container base images ---
+  - package-ecosystem: "docker"
+    directories:
+      - "/bridge"
+      - "/dashboard"
+      - "/server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(docker)"
+
+  # --- workflow action pins ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20
+    commit-message:
+      prefix: "chore(ci)"
+    groups:
+      github-actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
This was written agentically; verify its assertions and edit accordingly:

## Why

Renovate has been this repo's only dependency-update tool, and **every run was
suppressed by Mend's platform-level `mode=silent`** — no PRs, no Dependency
Dashboard, nothing. That has now been switched off org-wide, but this repo was left
the most exposed of any in the org while it lasted: **39 open Dependabot
vulnerability alerts, 30 of them high severity**, across three npm workspaces and a
uv-managed Python service.

This is also the repo the original Dependabot→Renovate migration was most meant to
protect — npm is exactly the ecosystem the migration cited as under supply-chain
attack.

## What

Adds `.github/dependabot.yml` covering the full dependency surface, which nothing was
watching:

- **npm** — `/bridge`, `/bridge-app`, `/dashboard`
- **uv** — `/server` (`pyproject.toml` + `uv.lock`)
- **docker** — the `/bridge`, `/dashboard`, `/server` Dockerfiles
- **github-actions** — workflow pins

Group shapes and Conventional Commit prefixes mirror `renovate.json` so both tools'
output is directly comparable. Two behaviors are carried over deliberately:
`@electron-forge/*` gets its own group, and the DJ protocol libs
(`alphatheta-connect`, `stagelinq`) are excluded from grouped PRs so they keep
arriving individually for manual review.

Dependabot alerts and security updates were also enabled on the repo.

**Running both tools at once is deliberate and temporary** — it restores coverage now
and gives a side-by-side before we pick one. Expect duplicate PRs until then.

Heads up: with security updates enabled and 39 open alerts, merging this will produce
a burst of PRs. That is intended.

## Testing

- [ ] Dependabot parses the config without errors (Insights → Dependency graph → Dependabot)
- [ ] Each of the six ecosystem entries resolves its manifest (no "no manifest found" errors)
- [ ] Security-update PRs open against the existing 39 alerts
- [ ] Protocol-lib bumps arrive as individual PRs, not folded into a group
- [ ] CI green

🤖 Co-authored by Claude Opus 5 (1M context).
